### PR TITLE
Add startup video and server-side token storage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,61 @@
+import json
+import os
+import threading
+
+from flask import Flask, request, jsonify
 import telebot
+
 
 TOKEN = "8432849665:AAEsa0PTkBzpYZae0y6fsxiq38bRtpLFGvo"
 bot = telebot.TeleBot(TOKEN)
 
+app = Flask(__name__)
+TOKENS_FILE = "tokens.json"
+
+
+def load_tokens():
+    if os.path.exists(TOKENS_FILE):
+        try:
+            with open(TOKENS_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def save_tokens(data):
+    with open(TOKENS_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+@app.get("/tokens/<int:user_id>")
+def get_tokens(user_id: int):
+    data = load_tokens()
+    return jsonify({"tokens": data.get(str(user_id), 10000)})
+
+
+@app.post("/tokens/<int:user_id>")
+def set_tokens(user_id: int):
+    data = load_tokens()
+    payload = request.get_json(silent=True) or {}
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, int):
+        return jsonify({"error": "Invalid tokens"}), 400
+    data[str(user_id)] = tokens
+    save_tokens(data)
+    return jsonify({"status": "ok"})
+
+
 @bot.message_handler(commands=["start"])
 def start(message):
-    pass
-bot.polling(none_stop=True)
+    bot.reply_to(message, "Бот запущен")
+
+
+def run_bot():
+    bot.polling(none_stop=True)
+
+
+if __name__ == "__main__":
+    threading.Thread(target=run_bot, daemon=True).start()
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
+

--- a/index.html
+++ b/index.html
@@ -12,27 +12,50 @@
         #controls {margin-top: 40px;}
         #controls input {width: 80px; margin: 0 5px;}
         #countdown {margin-top: 20px; font-size: 24px;}
+
+        #splash {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: black;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 1000;
+        }
+        #splash video {
+            max-width: 100%;
+            height: auto;
+        }
     </style>
 </head>
 <body>
-    <div id="header">
-        <div id="tokens"></div>
-        <div id="username"></div>
+    <div id="splash">
+        <video id="introVideo" src="110661-689510387_medium.mp4" autoplay muted playsinline></video>
     </div>
-    <div id="price">Загрузка...</div>
-    <div id="time"></div>
 
-    <div id="controls">
-        <label>Время (с):
-            <input type="number" id="duration" min="10" max="1800" value="10">
-        </label>
-        <label>Ставка:
-            <input type="number" id="bet" min="1" max="100" value="1">
-        </label>
-        <button id="up">Up</button>
-        <button id="down">Down</button>
+    <div id="app" style="display:none">
+        <div id="header">
+            <div id="tokens"></div>
+            <div id="username"></div>
+        </div>
+        <div id="price">Загрузка...</div>
+        <div id="time"></div>
+
+        <div id="controls">
+            <label>Время (с):
+                <input type="number" id="duration" min="10" max="1800" value="10">
+            </label>
+            <label>Ставка:
+                <input type="number" id="bet" min="1" max="100" value="1">
+            </label>
+            <button id="up">Up</button>
+            <button id="down">Down</button>
+        </div>
+        <div id="countdown"></div>
     </div>
-    <div id="countdown"></div>
 
     <script>
         const tg = window.Telegram.WebApp;
@@ -40,6 +63,10 @@
         const user = tg.initDataUnsafe && tg.initDataUnsafe.user;
         const userEl = document.getElementById('username');
         const tokensEl = document.getElementById('tokens');
+        const splash = document.getElementById('splash');
+        const appEl = document.getElementById('app');
+        const introVideo = document.getElementById('introVideo');
+
         let userId = 'guest';
         if (user) {
             userId = user.id;
@@ -52,14 +79,39 @@
             userEl.textContent = 'Гость';
         }
 
-        const tokenKey = `tokens_${userId}`;
-        let tokens = parseInt(localStorage.getItem(tokenKey), 10);
-        if (isNaN(tokens)) tokens = 10000;
+        let tokens = 0;
         function updateTokens() {
             tokensEl.textContent = `Токены: ${tokens}`;
-            localStorage.setItem(tokenKey, tokens);
+            fetch(`/tokens/${userId}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ tokens })
+            });
         }
-        updateTokens();
+        async function loadTokens() {
+            try {
+                const res = await fetch(`/tokens/${userId}`);
+                if (res.ok) {
+                    const data = await res.json();
+                    tokens = data.tokens;
+                } else {
+                    tokens = 10000;
+                }
+            } catch (e) {
+                tokens = 10000;
+            }
+            updateTokens();
+        }
+        loadTokens();
+
+        function showApp() {
+            splash.style.display = 'none';
+            appEl.style.display = 'block';
+        }
+        introVideo.play().catch(showApp);
+        introVideo.addEventListener('playing', () => {
+            setTimeout(showApp, 2000);
+        });
 
         const priceEl = document.getElementById('price');
         const timeEl = document.getElementById('time');

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyTelegramBotAPI==4.22.1
+Flask==2.3.3


### PR DESCRIPTION
## Summary
- Show splash video for 2 seconds on load
- Persist tokens on a server so same user ID keeps coin balance across devices
- Add Flask server with token API

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7176114ac832195e45990fbcaa95f