### PR TITLE
Persist user token balances per Telegram ID

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,8 @@ TOKEN = "8432849665:AAEsa0PTkBzpYZae0y6fsxiq38bRtpLFGvo"
 bot = telebot.TeleBot(TOKEN)
 
 app = Flask(__name__)
-TOKENS_FILE = "tokens.json"
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+TOKENS_FILE = os.path.join(BASE_DIR, "tokens.json")
 TOKENS_LOCK = threading.Lock()
 
 

--- a/index.html
+++ b/index.html
@@ -80,14 +80,19 @@
         }
 
         let tokens = 0;
-        function updateTokens() {
+
+        function renderTokens() {
             tokensEl.textContent = `Токены: ${tokens}`;
+        }
+
+        function saveTokens() {
             fetch(`/tokens/${userId}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ tokens })
             });
         }
+
         async function loadTokens() {
             try {
                 const res = await fetch(`/tokens/${userId}`);
@@ -100,8 +105,9 @@
             } catch (e) {
                 tokens = 10000;
             }
-            updateTokens();
+            renderTokens();
         }
+
         loadTokens();
 
         function showApp() {
@@ -190,7 +196,8 @@
             } else {
                 tokens -= betAmount;
             }
-            updateTokens();
+            renderTokens();
+            saveTokens();
             durationInput.disabled = false;
             betInput.disabled = false;
             upBtn.disabled = false;


### PR DESCRIPTION
## Summary
- Persist token balances in a JSON file located alongside the bot script
- Separate token rendering and saving in the WebApp to avoid overwriting balances and save after bets

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7208a829c8321b9cbc8aeea50735f